### PR TITLE
Fix mutable default argument bug for logits_processor in Watermarker.generate()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "waterfall"
-version = "0.2.13"
+version = "0.2.14"
 authors = [
   { name = "Xinyuan Niu", email="aperture@outlook.sg" }
 ]

--- a/waterfall/WatermarkerBase.py
+++ b/waterfall/WatermarkerBase.py
@@ -195,9 +195,11 @@ class Watermarker:
     def find_largest_batch_size(
             self,
             tokd_inputs : List[BatchEncoding],
-            logits_processor : List[LogitsProcessor] = [],
+            logits_processor : List[LogitsProcessor] = None,
             **kwargs,
         ):
+        if logits_processor is None:
+            logits_processor = []
         longest_idx = np.argmax([tokd_input["input_ids"].shape[-1] for tokd_input in tokd_inputs])
         if "generation_config" in kwargs:
             generation_config = GenerationConfig(**kwargs["generation_config"].to_dict()) # copy
@@ -246,11 +248,14 @@ class Watermarker:
             use_tqdm : bool = False,
             batched_generate : bool = True,
             discard_incomplete : bool = True,
-            logits_processor = [],
+            logits_processor : List[LogitsProcessor] = None,
             **kwargs    # Other generate parameters
             ) -> List[str] | dict:  # Returns flattened list of query x beam
 
         assert self.model is not None, "Model is not loaded. Please load the model before generating text."
+
+        if logits_processor is None:
+            logits_processor = []
 
         is_single = isinstance(prompts, str) or isinstance(tokd_inputs, torch.Tensor)
         if is_single:


### PR DESCRIPTION
## Bug
`Watermarker.generate()` uses a mutable default argument `logits_processor=[]`. 
In Python, lists are mutable default arguments and thus only instantiated once 
when the function is defined. This means that all calls to all instances of `Watermarker` will 
reference the same global list, and append the `logits_processor` to that same list.
This behavior can be reproduced by creating multiple instances of Watermarker with unique IDs.
It can be observed that all resulting `T_ws` actually embed the first globally used ID instead of 
the ID of their own Watermarker. The reason for this is that all previous `LogitsProcessor` will be applied 
to the text.

 ## Expected behavior
Each call to `Watermarker.generate()` should create a fresh empty list of `logits_processor`,
especially across different Watermarker instances.

## Fix
Changed the default value of `logits_processor` to `None` and moved the empty
list initialization back inside the function. This way, it is still possible to pass an existing 
list of `LogitsProcessor`, but the default will again be an empty list, while avoiding the global list issue.
```
    if logits_processor is None:
        logits_processor = []
```
This bug was introduced in commit b05862a when the instantiation of the `logits_processor` list was moved from inside the `.generate()` method into a default argument.

I tested this fix in my own project and can confirm it works, produces the expected behavior when working with multiple 
Watermarker instances and does not break any backwards compatibility.